### PR TITLE
fix bugs when using SpanBert pretrained

### DIFF
--- a/pytorch_to_tf.py
+++ b/pytorch_to_tf.py
@@ -5,25 +5,39 @@ import tensorflow as tf
 from tensorflow.python.ops import variable_scope as vs
 from tensorflow.python.framework import ops
 
+tensors_to_transpose = (
+        "dense/kernel",
+        "attention/self/query",
+        "attention/self/key",
+        "attention/self/value"
+    )
 
-def convert_keys(model):
+var_map = (
+    ('layer.', 'layer_'),
+    ('word_embeddings.weight', 'word_embeddings'),
+    ('position_embeddings.weight', 'position_embeddings'),
+    ('token_type_embeddings.weight', 'token_type_embeddings'),
+    ('.', '/'),
+    ('LayerNorm/weight', 'LayerNorm/gamma'),
+    ('LayerNorm/bias', 'LayerNorm/beta'),
+    ('weight', 'kernel')
+)
+
+def to_tf_var_name(name: str):
+    for patt, repl in iter(var_map):
+        name = name.replace(patt, repl)
+    return '{}'.format(name)
+
+def my_convert_keys(model):
     converted = {}
-    for k, v in model.items():
-        new_k = k[len('decoder.'):].replace('layer.', 'layer_')
-        if new_k.endswith('.weight'):
-            replacement = '' if new_k.endswith('embeddings.weight') else '.kernel'
-            new_k = new_k.replace('.weight', replacement)
-        new_k = new_k.replace('.', '/')
-        new_k = new_k.replace('cls/predictions/bias', 'cls/predictions/output_bias')
-        new_k = new_k.replace('cls/seq_relationship/bias', 'cls/seq_relationship/output_bias')
-        new_k = new_k.replace('cls/seq_relationship/kernel', 'cls/seq_relationship/output_weights')
-        converted[new_k] = v
+    for k_pt, v in model.items():
+        k_tf =  to_tf_var_name(k_pt)
+        converted[k_tf] = v
     return converted
 
-
 def load_from_pytorch_checkpoint(checkpoint, assignment_map):
-    pytorch_model = torch.load(checkpoint, map_location='cpu')['model']
-    pt_model_with_tf_keys = convert_keys(pytorch_model)
+    pytorch_model = torch.load(checkpoint, map_location='cpu')
+    pt_model_with_tf_keys = my_convert_keys(pytorch_model)
     for _, name in assignment_map.items():
         store_vars = vs._get_default_variable_store()._vars
         var = store_vars.get(name, None)
@@ -32,7 +46,7 @@ def load_from_pytorch_checkpoint(checkpoint, assignment_map):
             print('WARNING:', name, 'not found in original model.')
             continue
         array = pt_model_with_tf_keys[name].cpu().numpy()
-        if name.endswith('kernel'):
+        if any([x in name for x in tensors_to_transpose]):
             array = array.transpose()
         assert tuple(var.get_shape().as_list()) == tuple(array.shape)
         init_value = ops.convert_to_tensor(array, dtype=np.float32)
@@ -43,8 +57,8 @@ def load_from_pytorch_checkpoint(checkpoint, assignment_map):
 def print_vars(pytorch_ckpt, tf_ckpt):
     tf_vars = tf.train.list_variables(tf_ckpt)
     tf_vars = {k:v for (k, v) in tf_vars}
-    pytorch_model = torch.load(pytorch_ckpt)['model']
-    pt_model_with_tf_keys = convert_keys(pytorch_model)
+    pytorch_model = torch.load(pytorch_ckpt)
+    pt_model_with_tf_keys = my_convert_keys(pytorch_model)
     only_pytorch, only_tf, common = [], [], []
     tf_only = set(tf_vars.keys())
     for k, v in pt_model_with_tf_keys.items():
@@ -57,7 +71,7 @@ def print_vars(pytorch_ckpt, tf_ckpt):
     print('Common', len(common))
     for k in common:
         array = pt_model_with_tf_keys[k].cpu().numpy()
-        if k.endswith('kernel'):
+        if any([x in k for x in tensors_to_transpose]):
             array = array.transpose()
         tf_shape = tuple(tf_vars[k])
         pt_shape = tuple(array.shape)


### PR DESCRIPTION
Fix bugs in _pytorch_to_tf.py_. Now the model can directly use SpanBert PyTorch pretrained models recently released from https://github.com/facebookresearch/SpanBERT. 